### PR TITLE
Added simple templating for custom coviu call posts

### DIFF
--- a/coviu-calls.php
+++ b/coviu-calls.php
@@ -74,9 +74,11 @@ function cvu_setup_options() {
 
 	add_option('coviu-video-calls', $options);
 
-	$plugin_template = plugin_dir_path( __FILE__ ) . 'single-cvu_session.php';
+	$theme_default_template = get_stylesheet_directory() . '/single.php';
 	$theme_template = get_stylesheet_directory() . '/single-cvu_session.php';
-	copy($plugin_template, $theme_template);
+	copy($theme_default_template, $theme_template);
+
+	file_put_contents('/var/www/html/error.log', ob_get_contents());
 }
 
 register_deactivation_hook( __FILE__, 'cvu_teardown_options' );
@@ -84,7 +86,6 @@ function cvu_teardown_options() {
 	delete_option('coviu-video-calls');
 
 	$theme_template = get_stylesheet_directory() . '/single-cvu_session.php';
-
 	if (file_exists($theme_template)) {
 		unlink($theme_template);
 	}

--- a/coviu-calls.php
+++ b/coviu-calls.php
@@ -77,8 +77,6 @@ function cvu_setup_options() {
 	$theme_default_template = get_stylesheet_directory() . '/single.php';
 	$theme_template = get_stylesheet_directory() . '/single-cvu_session.php';
 	copy($theme_default_template, $theme_template);
-
-	file_put_contents('/var/www/html/error.log', ob_get_contents());
 }
 
 register_deactivation_hook( __FILE__, 'cvu_teardown_options' );

--- a/coviu-calls.php
+++ b/coviu-calls.php
@@ -73,11 +73,21 @@ function cvu_setup_options() {
 	$options->embed_participant_pages = false;
 
 	add_option('coviu-video-calls', $options);
+
+	$plugin_template = plugin_dir_path( __FILE__ ) . 'single-cvu_session.php';
+	$theme_template = get_stylesheet_directory() . '/single-cvu_session.php';
+	copy($plugin_template, $theme_template);
 }
 
 register_deactivation_hook( __FILE__, 'cvu_teardown_options' );
 function cvu_teardown_options() {
 	delete_option('coviu-video-calls');
+
+	$theme_template = get_stylesheet_directory() . '/single-cvu_session.php';
+
+	if (file_exists($theme_template)) {
+		unlink($theme_template);
+	}
 }
 
 add_action( 'init', 'create_post_type' );

--- a/coviu-calls.php
+++ b/coviu-calls.php
@@ -111,20 +111,20 @@ function create_post_type() {
 
 add_filter( 'posttype_rewrite_rules', 'cvu_add_permastruct' );
 function cvu_add_permastruct( $rules ) {
-    $struct = '/%posttype%/%postname%/';
+	$struct = '/%posttype%/%postname%/';
 
-    global $wp_rewrite;
-    $rules = $wp_rewrite->generate_rewrite_rules(
-        $struct,
-        EP_PERMALINK,
-        false,
-        true,
-        true,
-        false,
-        true
-    );
+	global $wp_rewrite;
+	$rules = $wp_rewrite->generate_rewrite_rules(
+		$struct,
+		EP_PERMALINK,
+		false,
+		true,
+		true,
+		false,
+		true
+	);
 
-    return $rules;
+	return $rules;
 }
 
 /// ***   Admin Settings Page   *** ///

--- a/single-cvu_session.php
+++ b/single-cvu_session.php
@@ -1,6 +1,0 @@
-<?php
-// Simplest post template with no sidebar only displaying the first post
-get_header();
-the_post();
-the_content();
-get_footer();

--- a/single-cvu_session.php
+++ b/single-cvu_session.php
@@ -1,0 +1,6 @@
+<?php
+// Simplest post template with no sidebar only displaying the first post
+get_header();
+the_post();
+the_content();
+get_footer();


### PR DESCRIPTION
Calls that are embedded in wordpress posts now use a custom, editable template that is copied into the current wordpress theme upon plugin activation, and deleted on deactivation.